### PR TITLE
passing the mu-session-id in the header

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,7 +22,6 @@ app.get( '/', function( req, res ) {
 } );
 
 app.post( '/', function( req, res ) {
-  console.log("Post");
   if( process.env["LOG_REQUESTS"] ) {
     console.log("Logging request body");
     console.log(req.body);
@@ -34,8 +33,6 @@ app.post( '/', function( req, res ) {
   const originalMuCallId = req.get('mu-call-id');
   const muCallIdTrail = JSON.stringify( [...originalMuCallIdTrail, originalMuCallId] );
   const muSessionId = req.get('mu-session-id');
-
-  // console.log(muSessionId);
 
   changeSets.forEach( (change) => {
     change.insert = change.insert || [];


### PR DESCRIPTION
Most cases shouldn't use the mu-session-id but rather use the
mu-auth-allowed-groups, but there are situations where it's handy.

=> Example logging of change events

Therefore adding it.