### PR TITLE
add bundling

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The exported property contains an array of definitions, each linking a match to 
   - `options.resourceFormat`: Version format describing the format of the contents.  Keys may be added to this format, but they may not be removed.  Filter the properties as needed.
   - `options.gracePeriod`: Only send the response after a certain amount of time.  Groups deltas for this rule within this time frame and `mu-session-id` and `mu-auth-allowed-groups` and sends them in one go.
   - `options.ignoreFromSelf`: Don't inform about changes that originated from the microservice to be informed (based on the hostname).
-  - `options.retry`: (experimental) How many times the request is sent again on failure.  Defaults to 0.
+  - `options.retry`: (experimental) How many times the request is sent again on failure.  Defaults to 0. Warning: in case of retries, deltas may be received out of order!
   - `options.retryTimeout`: (experimental) How much time is left in between retries (in ms).  Currently defaults to 250ms.
 
 ## Delta formats

--- a/README.md
+++ b/README.md
@@ -67,8 +67,11 @@ The exported property contains an array of definitions, each linking a match to 
   - `callback.method`: Method to use when informing about a match
   - `options`: Options describing the match
   - `options.resourceFormat`: Version format describing the format of the contents.  Keys may be added to this format, but they may not be removed.  Filter the properties as needed.
-  - `options.gracePeriod`: Only send the response after a certain amount of time.  This will group changes in the future.
+  - `options.gracePeriod`: Only send the response after a certain amount of time.  Groups deltas within this time frame and `mu-session-id` and sends them in one go.
+  - `options.preciseBundling`: If `mu-auth-allowed-groups` change over deltas of the same `mu-session-id` (eg: when changing roles), setting this option will group delta messages by `mu-auth-allowed-groups`.  Assumes `gracePeriod` is set.  Defaults to `true`.
   - `options.ignoreFromSelf`: Don't inform about changes that originated from the microservice to be informed (based on the hostname).
+  - `options.retry`: (experimental) How many times the request is sent again on failure.  Defaults to 0.
+  - `options.retryTimeout`: (experimental) How much time is left in between retries (in ms).  Currently defaults to 250ms.
 
 ## Delta formats
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ The exported property contains an array of definitions, each linking a match to 
   - `callback.method`: Method to use when informing about a match
   - `options`: Options describing the match
   - `options.resourceFormat`: Version format describing the format of the contents.  Keys may be added to this format, but they may not be removed.  Filter the properties as needed.
-  - `options.gracePeriod`: Only send the response after a certain amount of time.  Groups deltas within this time frame and `mu-session-id` and sends them in one go.
-  - `options.preciseBundling`: If `mu-auth-allowed-groups` change over deltas of the same `mu-session-id` (eg: when changing roles), setting this option will group delta messages by `mu-auth-allowed-groups`.  Assumes `gracePeriod` is set.  Defaults to `true`.
+  - `options.gracePeriod`: Only send the response after a certain amount of time.  Groups deltas for this rule within this time frame and `mu-session-id` and `mu-auth-allowed-groups` and sends them in one go.
   - `options.ignoreFromSelf`: Don't inform about changes that originated from the microservice to be informed (based on the hostname).
   - `options.retry`: (experimental) How many times the request is sent again on failure.  Defaults to 0.
   - `options.retryTimeout`: (experimental) How much time is left in between retries (in ms).  Currently defaults to 250ms.

--- a/app.js
+++ b/app.js
@@ -1,8 +1,8 @@
-import { app, uuid } from 'mu';
+import { app } from 'mu';
 import services from './config/rules';
 import bodyParser from 'body-parser';
 import dns from 'dns';
-import http from 'http';
+import { sendRequest } from './send-request';
 
 // Log server config if requested
 if( process.env["LOG_SERVER_CONFIGURATION"] )
@@ -102,69 +102,6 @@ function tripleMatchesSpec( triple, matchSpec ) {
         return false;
   }
   return true; // no false matches found, let's send a response
-}
-
-
-function formatChangesetBody( changeSets, options ) {
-  if( options.resourceFormat == "v0.0.1" ) {
-    return JSON.stringify(
-      changeSets.map( (change) => {
-        return {
-          inserts: change.insert,
-          deletes: change.delete
-        };
-      } ) );
-  }
-  if( options.resourceFormat == "v0.0.0-genesis" ) {
-    // [{delta: {inserts, deletes}]
-    const newOptions = Object.assign({}, options, { resourceFormat: "v0.0.1" });
-    const newFormat = JSON.parse( formatChangesetBody( changeSets, newOptions ) );
-    return JSON.stringify({
-      // graph: Not available
-      delta: {
-        inserts: newFormat
-          .flatMap( ({inserts}) => inserts)
-          .map( ({subject,predicate,object}) =>
-                ( { s: subject.value, p: predicate.value, o: object.value } ) ),
-        deletes: newFormat
-          .flatMap( ({deletes}) => deletes)
-          .map( ({subject,predicate,object}) =>
-                ( { s: subject.value, p: predicate.value, o: object.value } ) )
-      }
-    });
-  } else {
-    throw `Unknown resource format ${options.resourceFormat}`;
-  }
-}
-
-async function sendRequest( entry, changeSets, muCallIdTrail, muSessionId ) {
-  let requestObject; // will contain request information
-
-  // construct the requestObject
-  const method = entry.callback.method;
-  const url = entry.callback.url;
-  const headers = { "Content-Type": "application/json", "MU-AUTH-ALLOWED-GROUPS": changeSets[0].allowedGroups, "mu-call-id-trail": muCallIdTrail, "mu-call-id": uuid() , "mu-session-id": muSessionId };
-
-  let body;
-  if( entry.options && entry.options.resourceFormat ) {
-    // we should send contents
-    body = formatChangesetBody( changeSets, entry.options );
-  }
-  if( process.env["DEBUG_DELTA_SEND"] )
-    console.log(`Executing send ${method} to ${url}`);
-  try {
-    const keepAliveAgent = new http.Agent({
-      keepAlive: true
-    });
-    const response = await fetch(url, { method, headers, body, agent: keepAliveAgent });
-    if (!response.ok) {
-      console.log(`Call to ${method} ${url} likely failed. Received status ${response.status}.`);
-    }
-  } catch(error) {
-    console.log(`Could not send request ${method} ${url}`);
-    console.log(error);
-    console.log(`NOT RETRYING`); // TODO: retry a few times when delta's fail to send
-  }
 }
 
 async function filterMatchesForOrigin( changeSets, entry ) {

--- a/bundle-requests.js
+++ b/bundle-requests.js
@@ -1,0 +1,72 @@
+import { sendRequest } from "./send-request.js";
+
+// map from bundle key to bundle object
+const bundles = {};
+
+const getBundleKey = (entry, muSessionId) => {
+  // should bundle with session id because SEAS sessions should be respected when handling deltas
+  return `${entry.index}-${muSessionId}`;
+};
+
+const sendBundledRequest = (bundleKey) => {
+  const bundle = bundles[bundleKey];
+  delete bundles[bundleKey];
+
+  if (!bundle) {
+    console.error(
+      `Bundle for key ${bundleKey} unexpectedly got handled already.`
+    );
+    return;
+  }
+
+  sendRequest(
+    bundle.entry,
+    bundle.originFilteredChangeSets,
+    bundle.muCallIdTrail,
+    bundle.muSessionId,
+    {
+      "mu-bundled-call-id-trails": bundle.bundledCallIdTrails.join(","),
+    }
+  );
+};
+
+export const prepareBundledRequest = (
+  entry,
+  originFilteredChangeSets,
+  muCallIdTrail,
+  muSessionId
+) => {
+  const bundleKey = getBundleKey(entry, muSessionId);
+  const existingBundle = bundles[bundleKey];
+
+  if (existingBundle) {
+    // change sets in bundle are simply added to the existing bundle, have client remove noops from it if desired
+    // as we don't know if noops are of interest to the client and we shouldn't judge
+    existingBundle.originFilteredChangeSets = [
+      ...bundles[bundleKey].originFilteredChangeSets,
+      ...originFilteredChangeSets,
+    ];
+    existingBundle.bundledCallIdTrails.push(muCallIdTrail);
+    // since an existing bundle exists, we don't need to send it after timeout,
+    // the existing bundle will send us too
+    if (process.env["DEBUG_DELTA_SEND"]) {
+      console.log(
+        `Adding to bundle for key ${bundleKey}, now contains ${existingBundle.originFilteredChangeSets.length} change sets`
+      );
+    }
+  } else {
+    if (process.env["DEBUG_DELTA_SEND"]) {
+      console.log(
+        `Creating bundle for key ${bundleKey}, sending in ${entry.options.gracePeriod}ms`
+      );
+    }
+    bundles[bundleKey] = {
+      entry,
+      originFilteredChangeSets,
+      muCallIdTrail,
+      muSessionId,
+      bundledCallIdTrails: [],
+    };
+    setTimeout(() => sendBundledRequest(bundleKey), entry.options.gracePeriod);
+  }
+};

--- a/bundle-requests.js
+++ b/bundle-requests.js
@@ -8,7 +8,7 @@ const getBundleKey = (entry, muSessionId) => {
   return `${entry.index}-${muSessionId}`;
 };
 
-const sendBundledRequest = (bundleKey) => {
+const executeBundledRequest = (bundleKey) => {
   const bundle = bundles[bundleKey];
   delete bundles[bundleKey];
 
@@ -30,7 +30,7 @@ const sendBundledRequest = (bundleKey) => {
   );
 };
 
-export const prepareBundledRequest = (
+export const sendBundledRequest = (
   entry,
   originFilteredChangeSets,
   muCallIdTrail,
@@ -67,6 +67,9 @@ export const prepareBundledRequest = (
       muSessionId,
       bundledCallIdTrails: [],
     };
-    setTimeout(() => sendBundledRequest(bundleKey), entry.options.gracePeriod);
+    setTimeout(
+      () => executeBundledRequest(bundleKey),
+      entry.options.gracePeriod
+    );
   }
 };

--- a/bundle-requests.js
+++ b/bundle-requests.js
@@ -1,21 +1,17 @@
 import { sendRequest } from "./send-request.js";
-import { createHash } from "node:crypto";
 
 // map from bundle key to bundle object
 const bundles = {};
 
 const getBundleKey = (entry, muSessionId, changeSets) => {
-  if (entry.options.preciseBundling) {
-    // more precise regarding allowed groups BUT slower since we're hashing a possibly longish string
-    const hash = createHash("sha256");
-
-    const allowedGroups = changeSets[0].allowedGroups;
-    hash.update(allowedGroups);
-    return `${entry.index}-${muSessionId}-${hash.digest("hex")}`;
-  } else {
-    return `${entry.index}-${muSessionId}`;
-  }
-  // should bundle with session id because SEAS sessions should be respected when handling deltas
+  const allowedGroups = changeSets[0].allowedGroups;
+  // should bundle with session id and allowedGroups because SEAS sessions and
+  // access rights should be respected when handling deltas
+  // note: allowedGroups is a json formatted string and can be long or out of order
+  // this means that in theory some requests will not be bundled that could be bundled
+  // in practice this hasn't happened yet and would simply create two bundles instead of one
+  // the total changeset over all bundles (multiple or one) would still be the same
+  return `${entry.index}-${muSessionId}-${allowedGroups}`;
 };
 
 const executeBundledRequest = (bundleKey) => {

--- a/config/rules.js
+++ b/config/rules.js
@@ -28,9 +28,6 @@ export default [
       retryTimeout: 250,
       // don't react to deltas from self
       ignoreFromSelf: true,
-      // Take the mu-auth-allowed-groups into account when bundling. 
-      // This is slower but more precise regarding access rights.
-      preciseBundling: true,
     }
   }
 ];

--- a/config/rules.js
+++ b/config/rules.js
@@ -7,5 +7,27 @@ export default [
     callback: {
       uri: "http://maildelivery/send", method: "PATCH"
     }
+  },
+  {
+    match: {
+      // react to any subject
+      subject: {}
+    },
+    callback: {
+      url: 'http://resource/.mu/delta',
+      method: 'POST'
+    },
+    options: {
+      // use the v0.0.1 format
+      resourceFormat: 'v0.0.1',
+      // bundle deltas for 10s after the first delta that comes in
+      gracePeriod: 10000,
+      // retry at most 3 times
+      retry: 3,
+      // wait 250ms before retrying
+      retryTimeout: 250,
+      // don't react to deltas from self
+      ignoreFromSelf: true,
+    }
   }
 ];

--- a/config/rules.js
+++ b/config/rules.js
@@ -28,6 +28,9 @@ export default [
       retryTimeout: 250,
       // don't react to deltas from self
       ignoreFromSelf: true,
+      // Take the mu-auth-allowed-groups into account when bundling. 
+      // This is slower but more precise regarding access rights.
+      preciseBundling: true,
     }
   }
 ];

--- a/send-request.js
+++ b/send-request.js
@@ -1,0 +1,89 @@
+import http from "http";
+import { uuid } from "mu";
+
+function formatChangesetBody(changeSets, options) {
+  if (options.resourceFormat == "v0.0.1") {
+    return JSON.stringify(
+      changeSets.map((change) => {
+        return {
+          inserts: change.insert,
+          deletes: change.delete,
+        };
+      })
+    );
+  }
+  if (options.resourceFormat == "v0.0.0-genesis") {
+    // [{delta: {inserts, deletes}]
+    const newOptions = Object.assign({}, options, { resourceFormat: "v0.0.1" });
+    const newFormat = JSON.parse(formatChangesetBody(changeSets, newOptions));
+    return JSON.stringify({
+      // graph: Not available
+      delta: {
+        inserts: newFormat
+          .flatMap(({ inserts }) => inserts)
+          .map(({ subject, predicate, object }) => ({
+            s: subject.value,
+            p: predicate.value,
+            o: object.value,
+          })),
+        deletes: newFormat
+          .flatMap(({ deletes }) => deletes)
+          .map(({ subject, predicate, object }) => ({
+            s: subject.value,
+            p: predicate.value,
+            o: object.value,
+          })),
+      },
+    });
+  } else {
+    throw `Unknown resource format ${options.resourceFormat}`;
+  }
+}
+
+export async function sendRequest(
+  entry,
+  changeSets,
+  muCallIdTrail,
+  muSessionId
+) {
+  let requestObject; // will contain request information
+
+  // construct the requestObject
+  const method = entry.callback.method;
+  const url = entry.callback.url;
+  const headers = {
+    "Content-Type": "application/json",
+    "MU-AUTH-ALLOWED-GROUPS": changeSets[0].allowedGroups,
+    "mu-call-id-trail": muCallIdTrail,
+    "mu-call-id": uuid(),
+    "mu-session-id": muSessionId,
+  };
+
+  let body;
+  if (entry.options && entry.options.resourceFormat) {
+    // we should send contents
+    body = formatChangesetBody(changeSets, entry.options);
+  }
+  if (process.env["DEBUG_DELTA_SEND"])
+    console.log(`Executing send ${method} to ${url}`);
+  try {
+    const keepAliveAgent = new http.Agent({
+      keepAlive: true,
+    });
+    const response = await fetch(url, {
+      method,
+      headers,
+      body,
+      agent: keepAliveAgent,
+    });
+    if (!response.ok) {
+      console.log(
+        `Call to ${method} ${url} likely failed. Received status ${response.status}.`
+      );
+    }
+  } catch (error) {
+    console.log(`Could not send request ${method} ${url}`);
+    console.log(error);
+    console.log(`NOT RETRYING`); // TODO: retry a few times when delta's fail to send
+  }
+}

--- a/send-request.js
+++ b/send-request.js
@@ -56,6 +56,7 @@ const handleResponse = async (
     return;
   }
 
+  const { method, url } = entry.callback;
   console.log(
     `Call to ${method} ${url} likely failed. Received status ${response.status}.`
   );

--- a/send-request.js
+++ b/send-request.js
@@ -44,14 +44,14 @@ export async function sendRequest(
   entry,
   changeSets,
   muCallIdTrail,
-  muSessionId
+  muSessionId,
+  extraHeaders = {}
 ) {
-  let requestObject; // will contain request information
-
   // construct the requestObject
   const method = entry.callback.method;
   const url = entry.callback.url;
   const headers = {
+    ...extraHeaders,
     "Content-Type": "application/json",
     "MU-AUTH-ALLOWED-GROUPS": changeSets[0].allowedGroups,
     "mu-call-id-trail": muCallIdTrail,

--- a/send-request.js
+++ b/send-request.js
@@ -94,7 +94,7 @@ export async function sendRequest(
 
     if (retriesLeft > 0) {
       retriesLeft = retriesLeft - 1;
-      console.log(`RETRYING (${livesLeft} left)`);
+      console.log(`RETRYING (${retriesLeft} left)`);
       await new Promise((resolve) =>
         setTimeout(resolve, entry.retryTimeout || DEFAULT_RETRY_TIMEOUT)
       );


### PR DESCRIPTION
This PR adds bundling requests if a service specifies a grace-period. With debug logs on, this results in:
```
deltanotifier-1  | Rebuilding sources to include /config.
deltanotifier-1  | Successfully compiled 6 files with Babel (254ms).
deltanotifier-1  | Successfully compiled 3 files with Babel (261ms).
deltanotifier-1  | Starting server on 0.0.0.0:80 in production mode
deltanotifier-1  | Going to send POST to http://ldes-delta-pusher/publish
deltanotifier-1  | Creating bundle for key 1-http://mu.semte.ch/sessions/d7773ca0-dd5b-11ee-befb-0242ac120005, sending in 10000ms
deltanotifier-1  | Going to send POST to http://resource/.mu/delta
deltanotifier-1  | Creating bundle for key 0-http://mu.semte.ch/sessions/d7773ca0-dd5b-11ee-befb-0242ac120005, sending in 250ms
deltanotifier-1  | Executing send POST to http://resource/.mu/delta
deltanotifier-1  | Going to send POST to http://ldes-delta-pusher/publish
deltanotifier-1  | Adding to bundle for key 1-http://mu.semte.ch/sessions/d7773ca0-dd5b-11ee-befb-0242ac120005, now contains 3 change sets
deltanotifier-1  | Going to send POST to http://ldes-delta-pusher/publish
deltanotifier-1  | Adding to bundle for key 1-http://mu.semte.ch/sessions/d7773ca0-dd5b-11ee-befb-0242ac120005, now contains 5 change sets
deltanotifier-1  | Going to send POST to http://ldes-delta-pusher/publish
deltanotifier-1  | Adding to bundle for key 1-http://mu.semte.ch/sessions/d7773ca0-dd5b-11ee-befb-0242ac120005, now contains 7 change sets
deltanotifier-1  | Going to send POST to http://ldes-delta-pusher/publish
deltanotifier-1  | Adding to bundle for key 1-http://mu.semte.ch/sessions/d7773ca0-dd5b-11ee-befb-0242ac120005, now contains 9 change sets
deltanotifier-1  | Going to send POST to http://ldes-delta-pusher/publish
deltanotifier-1  | Adding to bundle for key 1-http://mu.semte.ch/sessions/d7773ca0-dd5b-11ee-befb-0242ac120005, now contains 11 change sets
deltanotifier-1  | Going to send POST to http://resource/.mu/delta
deltanotifier-1  | Creating bundle for key 0-http://mu.semte.ch/sessions/d7773ca0-dd5b-11ee-befb-0242ac120005, sending in 250ms
deltanotifier-1  | Executing send POST to http://resource/.mu/delta
deltanotifier-1  | Going to send POST to http://ldes-delta-pusher/publish
deltanotifier-1  | Adding to bundle for key 1-http://mu.semte.ch/sessions/d7773ca0-dd5b-11ee-befb-0242ac120005, now contains 12 change sets
deltanotifier-1  | Going to send POST to http://ldes-delta-pusher/publish
deltanotifier-1  | Adding to bundle for key 1-http://mu.semte.ch/sessions/d7773ca0-dd5b-11ee-befb-0242ac120005, now contains 14 change sets
deltanotifier-1  | Going to send POST to http://ldes-delta-pusher/publish
deltanotifier-1  | Adding to bundle for key 1-http://mu.semte.ch/sessions/d7773ca0-dd5b-11ee-befb-0242ac120005, now contains 16 change sets
deltanotifier-1  | Going to send POST to http://ldes-delta-pusher/publish
deltanotifier-1  | Adding to bundle for key 1-http://mu.semte.ch/sessions/d7773ca0-dd5b-11ee-befb-0242ac120005, now contains 18 change sets
deltanotifier-1  | Executing send POST to http://ldes-delta-pusher/publish
```
My service that uses the delta notifier correctly only receives one combined changeset.

The PR also includes a retry mechanism (configurable) since I found a TODO in the code for that. It also extracts the sendRequest function to a separate file to keep the app.js a little more concise.