### PR TITLE
add an option to send only matches to receiving services

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The exported property contains an array of definitions, each linking a match to 
   - `options.ignoreFromSelf`: Don't inform about changes that originated from the microservice to be informed (based on the hostname).
   - `options.retry`: (experimental) How many times the request is sent again on failure.  Defaults to 0. Warning: in case of retries, deltas may be received out of order!
   - `options.retryTimeout`: (experimental) How much time is left in between retries (in ms).  Currently defaults to 250ms.
+  - `options.sendMatchesOnly`: Only send triples that match, removing the other triples from the changes.
 
 ### Modifying quads
 #### Normalize datetime


### PR DESCRIPTION
A lot of services only care about certain triples, having this filtering logic in one place seem logical to me. 
This greatly reduces the size of delta messages in stacks with large data changes, limiting the amount of json serialization that needs to be done at both ends.

NOTE: this currently only adapts insert and delete on a changeSet, but not the effectiveInsert and effectiveDelete. If this feature is deemed useful I can quite easily extend the logic to also filter those.
